### PR TITLE
To pass static analyses

### DIFF
--- a/lib/src/indicator/bezier_indicator.dart
+++ b/lib/src/indicator/bezier_indicator.dart
@@ -4,8 +4,6 @@
  * Time:  2019-08-02 19:20
  */
 
-import 'package:flutter/animation.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:pull_to_refresh_flutter3/pull_to_refresh_flutter3.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart' hide RefreshIndicator, RefreshIndicatorState;


### PR DESCRIPTION
INFO: The import of 'package:flutter/animation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/cupertino.dart'.
lib/src/indicator/bezier_indicator.dart:7:8
INFO: The import of 'package:flutter/cupertino.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'.
lib/src/indicator/bezier_indicator.dart:8:8